### PR TITLE
Update gopigoMinimal_rviz_simple.launch

### DIFF
--- a/Chapter4_RViz_basics/launch/gopigoMinimal_rviz_simple.launch
+++ b/Chapter4_RViz_basics/launch/gopigoMinimal_rviz_simple.launch
@@ -8,7 +8,7 @@
    <node pkg="joint_state_publisher" type="joint_state_publisher" name="joint_state_publisher"/>
 
    <!-- Combine joint values to TF-->
-   <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher"/>
+   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 
    <node name="rviz" pkg="rviz" type="rviz" args="-d $(find rviz_basics)/rviz/gopigoMinimal.rviz" required="true" />
 </launch>


### PR DESCRIPTION
Trying to launch i get this error: 
`ERROR: cannot launch node of type [robot_state_publisher/state_publisher]: Cannot locate node of type [state_publisher] in package [robot_state_publisher]. Make sure file exists in package path and permission is set to executable (chmod +x)`, I found that by changing this line, it could be solved.