### PR TITLE
Update gopigoMinimal_rviz.launch

### DIFF
--- a/Chapter4_RViz_basics/launch/gopigoMinimal_rviz.launch
+++ b/Chapter4_RViz_basics/launch/gopigoMinimal_rviz.launch
@@ -13,7 +13,7 @@
      <param name="/use_gui" value="$(arg gui)"/>
    </node>
    <!-- Combine joint values to TF-->
-   <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher"/>
+   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 
    <node name="rviz" pkg="rviz" type="rviz" args="-d $(find rviz_basics)/rviz/$(arg model).rviz" required="true" />
    <!-- (required = "true") if rviz dies, entire roslaunch will be killed -->


### PR DESCRIPTION
Trying to launch i get this error:
`ERROR: cannot launch node of type [robot_state_publisher/state_publisher]: Cannot locate node of type [state_publisher] in package [robot_state_publisher]. Make sure file exists in package path and permission is set to executable (chmod +x)`, I found that by changing this line, it could be solved.